### PR TITLE
test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         conda-channels: anaconda
     - run: conda --version
     - run: which python
-    - run: conda install pytorch torchvision cpuonly -c pytorch -c conda-forge
+    - run: conda install mpi4py h5py==3.1.0 pytorch torchvision cpuonly -c pytorch -c conda-forge
 
     - name: Install the package
       run: pip install .[test,hpc]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         conda-channels: anaconda
     - run: conda --version
     - run: which python
-    - run: conda install mpi4py h5py pytorch torchvision cpuonly -c pytorch -c conda-forge
+    - run: conda install pytorch torchvision cpuonly -c pytorch -c conda-forge
 
     - name: Install the package
       run: pip install .[test,hpc]

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ setup(
     install_requires=['matplotlib', 'numpy', 'argparse',
                       'scipy', 'tqdm', 'torch',
                       # 'plams@git+https://github.com/SCM-NV/PLAMS@master',
-                      'plams', 'h5py',
+                      'plams',
                       'pyscf', 'mendeleev', 'twiggy'],
 
     extras_require={
-        'hpc': ['horovod', 'mpi4py'],
+        'hpc': ['horovod'],
         'doc': ['recommonmark', 'sphinx', 'sphinx_rtd_theme'],
         'test': ['pytest', 'pytest-runner',
                  'coverage', 'coveralls', 'pycodestyle'],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=['matplotlib', 'numpy', 'argparse',
                       'scipy', 'tqdm', 'torch',
                       # 'plams@git+https://github.com/SCM-NV/PLAMS@master',
-                      'plams',
+                      'plams', 'h5py',
                       'pyscf', 'mendeleev', 'twiggy'],
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -53,3 +53,5 @@ setup(
                  'coverage', 'coveralls', 'pycodestyle'],
     }
 )
+
+


### PR DESCRIPTION
The version 3.3.0 of h5py conflicts with pyscf. This patch restrict h5py to 3.1.0 