### PR TITLE
make mpi4py/pyscf optional to run on windows

### DIFF
--- a/qmctorch/scf/calculator/__init__.py
+++ b/qmctorch/scf/calculator/__init__.py
@@ -1,5 +1,3 @@
-__all__ = ['CalculatorBase', 'CalculatorADF', 'CalculatorPySCF']
+__all__ = ['CalculatorBase']
 
 from .calculator_base import CalculatorBase
-from .adf import CalculatorADF
-from .pyscf import CalculatorPySCF

--- a/qmctorch/scf/molecule.py
+++ b/qmctorch/scf/molecule.py
@@ -5,8 +5,6 @@ from mendeleev import element
 from types import SimpleNamespace
 import h5py
 
-from .calculator.adf import CalculatorADF
-from .calculator.pyscf import CalculatorPySCF
 
 from ..utils import dump_to_hdf5, load_from_hdf5, bytes2str
 from .. import log
@@ -15,6 +13,16 @@ try:
     from mpi4py import MPI
 except ModuleNotFoundError:
     log.info('  MPI not found.')
+
+try:
+    from .calculator.adf import CalculatorADF
+except:
+    log.info(' ADF calculator not found')
+
+try:
+    from .calculator.pyscf import CalculatorPySCF
+except:
+    log.info(' PySCF calculator not found')
 
 
 class Molecule:


### PR DESCRIPTION
Running on Windows can be interesting at least for debugging GPU on my machine atm